### PR TITLE
Resolve Certik audit findings

### DIFF
--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -541,6 +541,8 @@ contract FLOKI is Context, IERC20, Ownable {
     }
 
     function setMarketingAddress(address _marketingAddress) external onlyOwner {
+        require(_marketingAddress != address(0), "FLOKI: Invalid marketing address");
+
         address _oldMarketingAddress = marketingAddress;
 
         marketingAddress = payable(_marketingAddress);

--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicensed
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";

--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -162,15 +162,6 @@ contract FLOKI is Context, IERC20, Ownable {
         return _tFeeTotal;
     }
 
-    function deliver(uint256 tAmount) public {
-        address sender = _msgSender();
-        require(!_isExcluded[sender], "Excluded addresses cannot call this function");
-        (uint256 rAmount, , , , , ) = _getValues(tAmount);
-        _rOwned[sender] = _rOwned[sender].sub(rAmount);
-        _rTotal = _rTotal.sub(rAmount);
-        _tFeeTotal = _tFeeTotal.add(tAmount);
-    }
-
     function reflectionFromToken(uint256 tAmount, bool deductTransferFee) public view returns (uint256) {
         require(tAmount <= _tTotal, "Amount must be less than supply");
         if (!deductTransferFee) {

--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -545,11 +545,11 @@ contract FLOKI is Context, IERC20, Ownable {
         recipient.transfer(amount);
     }
 
-    function isRemovedSniper(address account) public view returns (bool) {
+    function isSniper(address account) public view returns (bool) {
         return _isSniper[account];
     }
 
-    function _removeSniper(address account) external onlyOwner {
+    function setSniper(address account) external onlyOwner {
         require(account != 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D, "We can not blacklist Uniswap");
         require(!_isSniper[account], "Account is already blacklisted");
         _isSniper[account] = true;

--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -53,6 +53,11 @@ contract FLOKI is Context, IERC20, Ownable {
 
     event SwapTokensForETH(uint256 amountIn, address[] path);
 
+    event UpdatedTaxFee(uint256 oldTaxFee, uint256 newTaxFee);
+    event UpdatedLiquidityFee(uint256 oldiquidityFee, uint256 newLiquidityFee);
+    event UpdatedFeeRate(uint256 oldFeeRate, uint256 newFeeRate);
+    event UpdatedMarketingAddress(address oldAddress, address newAddress);
+
     modifier lockTheSwap() {
         inSwapAndLiquify = true;
         _;
@@ -520,15 +525,27 @@ contract FLOKI is Context, IERC20, Ownable {
     }
 
     function setTaxFeePercent(uint256 taxFee) external onlyOwner {
+        uint256 _oldTaxFee = _taxFee;
+
         _taxFee = taxFee;
+
+        emit UpdatedTaxFee(_oldTaxFee, taxFee);
     }
 
     function setLiquidityFeePercent(uint256 liquidityFee) external onlyOwner {
+        uint256 _oldLiquidityFee = _liquidityFee;
+
         _liquidityFee = liquidityFee;
+
+        emit UpdatedLiquidityFee(_oldLiquidityFee, liquidityFee);
     }
 
     function setMarketingAddress(address _marketingAddress) external onlyOwner {
+        address _oldMarketingAddress = marketingAddress;
+
         marketingAddress = payable(_marketingAddress);
+
+        emit UpdatedMarketingAddress(_oldMarketingAddress, marketingAddress);
     }
 
     function transferToAddressETH(address payable recipient, uint256 amount) private {
@@ -559,7 +576,11 @@ contract FLOKI is Context, IERC20, Ownable {
     }
 
     function setFeeRate(uint256 rate) external onlyOwner {
+        uint256 _oldRate = _feeRate;
+
         _feeRate = rate;
+
+        emit UpdatedFeeRate(_oldRate, rate);
     }
 
     //to recieve ETH from uniswapV2Router when swaping

--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -297,21 +297,6 @@ contract FLOKI is Context, IERC20, Ownable {
         emit SwapTokensForETH(tokenAmount, path);
     }
 
-    function addLiquidity(uint256 tokenAmount, uint256 ethAmount) private {
-        // approve token transfer to cover all possible scenarios
-        _approve(address(this), address(uniswapV2Router), tokenAmount);
-
-        // add the liquidity
-        uniswapV2Router.addLiquidityETH{ value: ethAmount }(
-            address(this),
-            tokenAmount,
-            0, // slippage is unavoidable
-            0, // slippage is unavoidable
-            owner(),
-            block.timestamp
-        );
-    }
-
     function _tokenTransfer(
         address sender,
         address recipient,

--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -14,7 +14,6 @@ contract FLOKI is Context, IERC20, Ownable {
     using Address for address;
 
     address payable public marketingAddress = payable(0x2b9d5c7f2EAD1A221d771Fb6bb5E35Df04D60AB0); // Marketing Address
-    address public immutable deadAddress = 0x000000000000000000000000000000000000dEaD;
     mapping(address => uint256) private _rOwned;
     mapping(address => uint256) private _tOwned;
     mapping(address => mapping(address => uint256)) private _allowances;

--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -189,7 +189,7 @@ contract FLOKI is Context, IERC20, Ownable {
     }
 
     function includeInReward(address account) external onlyOwner {
-        require(_isExcluded[account], "Account is already excluded");
+        require(_isExcluded[account], "Account is not excluded");
         for (uint256 i = 0; i < _excluded.length; i++) {
             if (_excluded[i] == account) {
                 _excluded[i] = _excluded[_excluded.length - 1];

--- a/contracts/Floki.sol
+++ b/contracts/Floki.sol
@@ -25,7 +25,7 @@ contract FLOKI is Context, IERC20, Ownable {
     address[] private _excluded;
 
     uint256 private constant MAX = ~uint256(0);
-    uint256 private _tTotal = 10000000000000 * 10**9;
+    uint256 private _tTotal = 10**13 * 10**9;
     uint256 private _rTotal = (MAX - (MAX % _tTotal));
     uint256 private _tFeeTotal;
 


### PR DESCRIPTION
Findings resolved in various commits.

A few comments as replies to the findings:

`GLOBAL-01`
The centralized address is a Gnosis Safe multisig contract address, and currently an accepted risk.

`FCK-02`
This is an accepted risk. We chose specific versions of published OpenZeppelin and Uniswap contracts, and monitor the Uniswap V2 router and pool for any suspicious activity. We don't have a contingency plan at the moment for the case where Uniswap is compromized, but one option is to disable transfers to that pool entirely.

`FCK-05`
This has been mitigated on-chain. Funds were transferred into the deployer contract and then immediately transferred to the multisig, from where they were dispersed to the necessary addresses. For details see the following transactions:
 - [`0xe1514fb39877a52bd4d441632665628086b9d0a8caa8ad0d60c34aa2a54b319e`](https://etherscan.io/tx/0xe1514fb39877a52bd4d441632665628086b9d0a8caa8ad0d60c34aa2a54b319e)
 - [ `0xe8c04005a5ac00667a6b6e2c3f094ffe24fff9deee158459db180587706d8739`](https://etherscan.io/tx/0xe8c04005a5ac00667a6b6e2c3f094ffe24fff9deee158459db180587706d8739)

`FCK-09`
The `deliver` function allows users to donate funds fully as "marketing tax". A better name would have been "donate". Nobody has ever used this. Removed in one of the commits of this PR. Users that want to do this can transfer their funds directly to the marketing multisig address.

`FCK-11`
Technically its accuracy is ~13 seconds, due to Ethereum block times taking that long. One might still wonder whether a honey pot of 1 block is sufficient to catch the mempool snipers, but we've seen regular users start pouring in within seconds as well, and didn't wish to blacklist them.